### PR TITLE
reduce package file size

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,21 +7,23 @@
 
 'use strict';
 
-var is = require('assert-kindof');
-var through2 = require('through2');
+var Transform = require('readable-stream/transform');
 
 var label = 'vinyl-filter-since';
 
 module.exports = function vinylFilterSince(since) {
-  if (!is.kindof(since, 'date') && !is.kindof(since, 'number')) {
+  if (!(since instanceof Date) && typeof since !== 'number') {
     throw new TypeError(label + ':15, expect `since` to be date or number.');
   }
 
-  return through2.obj(function(file, enc, next) {
-    if (since < file.stat.mtime) {
-      next(null, file);
-      return;
+  return new Transform({
+    objectMode: true,
+    transform: function(file, enc, next) {
+      if (since < file.stat.mtime) {
+        this.push(file);
+        return;
+      }
+      next();
     }
-    next();
   });
 };

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "email": "mameto_100@mail.bg",
     "url": "https://github.com/tunnckoCore"
   },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/tunnckoCore/vinyl-filter-since.git"
-  },
+  "repository": "tunnckoCore/vinyl-filter-since",
+  "files": [
+    "index.js"
+  ],
   "keywords": [
     "file",
     "filter",
@@ -30,16 +30,13 @@
     "util",
     "vinyl"
   ],
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/tunnckoCore/vinyl-filter-since/blob/master/license.md"
-  },
+  "license": "MIT",
   "dependencies": {
-    "assert-kindof": "~1.0.0",
-    "through2": "~2.0.0"
+    "readable-stream": "^2.0.1"
   },
   "devDependencies": {
-    "gulp": "~3.8.11",
-    "lab": "~5.5.1"
+    "lab": "^5.12.1",
+    "through2": "^2.0.0",
+    "vinyl-fs": "^1.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -7,11 +7,11 @@
 
 'use strict';
 
+var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
-var gulp = require('gulp');
-var assert = require('assert');
-var vinylFilterSince = require('./index');
+var vinylFs = require('vinyl-fs');
+var vinylFilterSince = require('./');
 var through2 = require('through2');
 
 var fixture = path.join(__dirname, './package.json');
@@ -23,13 +23,11 @@ var it = lab.it;
 
 // DRY
 function testit(lastUpdateDate, len, done) {
-  var stream = gulp.src('*.json');
+  var stream = vinylFs.src('*.json');
   var files = [];
 
   stream
-    .pipe(through2.obj(function(file, enc, next) {
-      next(null, file);
-    }))
+    .pipe(through2.obj())
     .pipe(vinylFilterSince(lastUpdateDate))
     .pipe(through2.obj(function(file, enc, next) {
       files.push(file);


### PR DESCRIPTION
- use [readable-stream](https://github.com/nodejs/readable-stream) module directly, instead of [through2](https://github.com/rvagg/through2)
- remove huge [assert-kindof](https://github.com/tunnckoCore/assert-kindof) module and add hard-coded type checking
- use [vinyl-fs](https://github.com/wearefractal/vinyl-fs) directly, instead of [gulp](https://github.com/gulpjs/gulp)
- add `files` field to package.json to exclude unnecessary files form the npm package
- simplify `license` field and `repository` field
### Package file size
#### Current `master`

```
$ npm i tunnckoCore/vinyl-filter-since#58c40780ee77622100d72b430b67e60c330e7bd4
vinyl-filter-since@2.0.0 node_modules/vinyl-filter-since
├── assert-kindof@1.0.1 (kind-of@1.1.0, is-kindof@1.0.0)
└── through2@2.0.0 (xtend@4.0.0, readable-stream@2.0.1)
$ du -sh node_modules/vinyl-filter-since
556K    node_modules/vinyl-filter-since
```
#### After merging this PR

```
$ npm i shinnn/vinyl-filter-since#745649471e25cc6ae0bead91e183ce5b2ee43
283
vinyl-filter-since@2.0.0 node_modules/vinyl-filter-since
└── readable-stream@2.0.1 (process-nextick-args@1.0.1, inherits@2.0.1, isarray@0.0.1, string_decoder@0.10.31, util-deprecate@1.0.1, core-util-is@1.0.1)
$ du -sh node_modules/vinyl-filter-since
324K    node_modules/vinyl-filter-since
```
